### PR TITLE
Updated Parsing to Support Filename: and Longer Commit Hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /lex.yy.c
 /cvsclone
+
+*.dSYM

--- a/cvsclone.l
+++ b/cvsclone.l
@@ -450,8 +450,10 @@ void begin(char *s, size_t l)
 <ATR1>-[0-9]+;\ \       BEGIN ATR0; rfile.revt->ldel = atoi(yytext+1);
 <ATR0>kopt:\ [^;\n]+;\n BEGIN REV3; rfile.revt->kopt = getstr(yyleng-8, yytext+6);
 <ATR0>kopt:\ [^;\n]+;\ \  rfile.revt->kopt = getstr(yyleng-9, yytext+6);
-<ATR0>commitid:\ [0-9a-f]{16};\ \  rfile.revt->commitid = getstr(16, yytext+10);
-<ATR0>commitid:\ [0-9a-f]{16};\n BEGIN REV3; rfile.revt->commitid = getstr(16, yytext+10);
+<ATR0>commitid:\ [0-9a-f]{10,20};\ \  rfile.revt->commitid = getstr(yyleng-11, yytext+10);
+<ATR0>commitid:\ [0-9a-f]{10,20};\n BEGIN REV3; rfile.revt->commitid = getstr(yyleng-11, yytext+10);
+<ATR0>filename:\ [^;]+;\n  BEGIN REV3; rfile.revt->ldel = atoi(yytext+1);
+<ATR0>filename:\ [^;]+;\ \  BEGIN ATR0; rfile.revt->ldel = atoi(yytext+1);
 <ATR0>mergepoint:\ {num};\n BEGIN REV3; /* getstr(yyleng-14, yytext+12); */
 <REV3>branches:/.*\n    BEGIN RLST;
 <REV3,REV4>={77}\n      BEGIN FEND; *yytext = '\0'; if (!rfile.revt->log) rfile.revt->log = yytext; if (rfile.revt) rfile.revt++;

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,67 @@
+# cvsclone
+
+Utility to clone cvs repositories over the cvspserver interface.
+
+As ```git cvsimport``` is pretty slow over the wire (and as [cvs2git](http://cvs2svn.tigris.org/cvs2git.html) can do a substantially better job if there are a lot of branches), it is often better to "clone" a whole CVS repository. Enter cvsclone!
+
+## Features
+
+- Works with anonymous access. Will read $HOME/.cvspass if needed
+- Can clone corrupt repositories: writes ,v files directly, does not need rcs (For example, ccvs module has archives that go backwards in time).
+
+## Building
+
+You will need [Flex](http://flex.sourceforge.net/) installed to create cvsclone. You can normally find this in your package manager i.e:
+
+```bash
+> apt-get install flex
+```
+
+Use [Homebrew](http://brew.sh/) on OS X:
+```bash
+> brew install flex
+```
+
+Once installed, clone this repository and build using **make**:
+
+```bash
+> git clone
+> cd cvsclone
+> make
+```
+
+The **cvsclone** binary should be output into the same folder and ready to use.
+
+## Using
+
+Set up your $CVSROOT to point to your repository of choice. You will need to log into CVS first so that your credentials are on the machine:
+
+```bash
+> set $CVSROOT=:pserver:your.user@mycvsserver.com:/SomeRepo
+> cvs login
+```
+
+To clone the repository, use ```./cvsclone -d <connect pserver string> <module>```. For example:
+
+```bash
+> ./cvsclone -d $CVSROOT mymodule
+```
+
+Your repository should be converted and placed in a folder with the modules name.
+
+## History
+
+Originally written by Peter Backes. Check the header in [cvsclone.i](./cvsclone.i) for more details.
+
+Additional fixes by [Mateusz Czapliński](https://github.com/akavel/cvsclone) (which this version is based on) allowing to pipe the output of "cvs rlog" into a file, editing the file to fix errors (such as geniuses who put the cvs log of moved files into a commit message) and use that file as input instead.
+
+## Known Issues
+
+- Can't enable compression
+- Reading CVS password from $HOME/.cvspass uses $CVSROOT in a case sensitive way
+- rlog format is ambiguous. If the separators it uses are found inside log messages, possibly followed by lines similar to what rlog outputs, things can go wrong horribly
+- rcs 5.x rlog format does not contain the comment leader. It is guessed according to the extension as rcs and CVS do
+- Uses normal diff format since this is the easiest one that works. ```diff --rcs``` is problematic, since files without newline at the last line are not output correctly. The major drawback about this is that deleted lines are transferred while they don't need to be. Even rdiff has major problems with lines that contain \0, because of a bug in CVS
+- does not work incrementally. That would be much more work if updating the trunk since the most recent revision had to be reconstructed.  Also, the whole history probably had to be transferred again, with all log messages
+- Horrible complexity. A file with n deltas takes O(n^2) to transfer
+- Makes the cvs server really work hard, taking up all processor time. It should really not be used on public cvs servers, especially not on a regular basis. Perhaps it is useful for salvaging archive files from projects where only access to anonymous cvs is available

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,0 @@
-ORIGINAL README FROM BASE git REPO BY Johannes Schindelin @ http://repo.or.cz/w/cvsclone.git:
-
-As git cvsimport is pretty slow over the wire (and as cvs2git can do a substantially better job if there are a lot of branches), it is often better to "clone" a whole CVS repository. Enter cvsclone, written by Peter Backes.
-
-You can find a few touchups by yours truly here, allowing to pipe the output of "cvs rlog" into a file, editing the file to fix errors (such as geniuses who put the cvs log of moved files into a commit message) and use that file as input instead. 


### PR DESCRIPTION
Updated the parsing so that it:
- Allows for **filename:** support (doesn't use it, just strips it out)
- Allows for the **commitid:** hashes to range between 10 and 20 characters

Move the readme into a markdown file and added in sections from the cvsclone.l header so it's a little easier to read. 
